### PR TITLE
Move supplier dashboard to dedicated module

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from sup_signin import sign_in_with_google
 from supplier.supplier_handler import get_or_create_supplier
 from home import show_home_page
 from purchase_order.main_po import show_main_po_page  # 🔥 Updated import for PO management
+from supplier.supplier import show_supplier_dashboard
 
 def main():
     """Main entry point for the AMAS Supplier App."""
@@ -27,17 +28,6 @@ def main():
         show_main_po_page(supplier)  # 🔥 Now using `main_po.py` to manage PO pages
     else:
         show_supplier_dashboard(supplier)
-
-def show_supplier_dashboard(supplier):
-    """Displays the supplier dashboard."""
-    st.subheader("📊 Supplier Dashboard")
-    st.write(f"Welcome, **{supplier['suppliername']}**!")
-    st.write(f"Your Supplier ID is: **{supplier['supplierid']}**")
-
-    # Logout button
-    if st.button("Log out"):
-        st.logout()
-        st.rerun()
 
 if __name__ == "__main__":
     main()

--- a/supplier/supplier.py
+++ b/supplier/supplier.py
@@ -1,0 +1,12 @@
+import streamlit as st
+
+
+def show_supplier_dashboard(supplier):
+    """Display the supplier dashboard."""
+    st.subheader("\U0001F4CA Supplier Dashboard")
+    st.write(f"Welcome, **{supplier['suppliername']}**!")
+    st.write(f"Your Supplier ID is: **{supplier['supplierid']}**")
+
+    if st.button("Log out"):
+        st.logout()
+        st.rerun()


### PR DESCRIPTION
## Summary
- extract supplier dashboard logic to `supplier/supplier.py`
- import and use the new module in `app.py`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683b0ab334248331aed9c41e0e6ab1bf